### PR TITLE
Dropping support for old Android versions

### DIFF
--- a/aerogear-android-push-test/src/main/AndroidManifest.xml
+++ b/aerogear-android-push-test/src/main/AndroidManifest.xml
@@ -16,9 +16,7 @@
   limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jboss.aerogear.android.unifiedpush.test"
-    android:versionCode="1"
-    android:versionName="1.0" >
+    package="org.jboss.aerogear.android.unifiedpush.test">
 
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
 

--- a/aerogear-android-push/src/main/AndroidManifest.xml
+++ b/aerogear-android-push/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
   limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jboss.aerogear.android.unifiedpush"
-    android:versionCode="1"
-    android:versionName="1.0">
+    package="org.jboss.aerogear.android.unifiedpush">
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
 </manifest>


### PR DESCRIPTION
We are dropping support for the old Android versions. For more informations see [Android Dashboard](https://developer.android.com/about/dashboards/index.html)

Jira: [AGDROID-310](https://issues.jboss.org/browse/AGDROID-310)
