### PR TITLE
Rename getRegistrar to the same of the other libraries

### DIFF
--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/RegistrarManager.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/RegistrarManager.java
@@ -103,7 +103,7 @@ public class RegistrarManager {
      * 
      * @return the named {@link PushRegistrar} or null
      */
-    public static PushRegistrar getRegistrar(String name) {
+    public static PushRegistrar get(String name) {
         return registrars.get(name);
     }
 


### PR DESCRIPTION
The libraries are using `get` instead of `getXXX` in the Managers