### PR TITLE
Increasing timeout on unregister latch

### DIFF
--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushRegistrarTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushRegistrarTest.java
@@ -211,11 +211,11 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         spy.register(super.getActivity(), callback);
         latch.await(1, TimeUnit.SECONDS);
 
-        latch = new CountDownLatch(1);
+        latch = new CountDownLatch(2);
         callback = new VoidCallback(latch);
         spy.unregister(super.getActivity(), callback);
         spy.unregister(super.getActivity(), callback);
-        latch.await(1, TimeUnit.SECONDS);
+        latch.await(2, TimeUnit.SECONDS);
 
         assertNotNull(callback.exception);
         assertTrue(callback.exception instanceof IllegalStateException);


### PR DESCRIPTION
Motivation
It seems like sometimes the timeout would hit before the second unregster call was placed.  This happened on an x86 emulator running 5.1 on my laptop.  Not sure what it could be but this fixes it