### PR TITLE
Agdroid 469 instance

### DIFF
--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -52,32 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-android-pipe</artifactId>
-            <version>${aerogear.android.pipe.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-android-core</artifactId>
-            <version>${aerogear.android.pipe.version}</version>
-            <scope>provided</scope>
-        </dependency>
-                <dependency>
-            <groupId>com.google.android.gms</groupId>
-            <artifactId>play-services-gcm</artifactId>
-            <version>7.5.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-android-push</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-       
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
@@ -117,19 +91,6 @@
             </exclusions>
         </dependency>
         
-        <dependency>
-            <groupId>com.android.support.test</groupId>
-            <artifactId>runner</artifactId>
-            <version>0.3</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.android.support.test</groupId>
-            <artifactId>rules</artifactId>
-            <version>0.3</version>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>com.android.support.test</groupId>

--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -51,6 +51,31 @@
             <type>aar</type>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-pipe</artifactId>
+            <version>${aerogear.android.pipe.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-core</artifactId>
+            <version>${aerogear.android.pipe.version}</version>
+            <scope>provided</scope>
+        </dependency>
+                <dependency>
+            <groupId>com.google.android.gms</groupId>
+            <artifactId>play-services-gcm</artifactId>
+            <version>7.5.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-push</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
        
         <dependency>
             <groupId>org.mockito</groupId>
@@ -96,6 +121,20 @@
             <groupId>com.android.support.test</groupId>
             <artifactId>runner</artifactId>
             <version>0.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>rules</artifactId>
+            <version>0.3</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>runner</artifactId>
+            <version>0.3</version>
             <type>aar</type>
             <exclusions>
                 <exclusion>
@@ -113,6 +152,14 @@
             <groupId>com.android.support.test</groupId>
             <artifactId>rules</artifactId>
             <version>0.3</version>
+            <type>aar</type>
+        </dependency>
+        
+        
+        <dependency>
+            <groupId>com.android.support</groupId>
+            <artifactId>support-v4</artifactId>
+            <version>22.2.0</version>
             <type>aar</type>
         </dependency>
         

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/RegistrationsTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/RegistrationsTest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import org.jboss.aerogear.android.core.ConfigurationProvider;
 import org.jboss.aerogear.android.unifiedpush.test.util.PatchedActivityInstrumentationTestCase;
-import org.jboss.aerogear.android.unifiedpush.test.MainActivity;
 import org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMPushConfiguration;
 import org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMPushRegistrar;
 import org.jboss.aerogear.android.unifiedpush.PushConfiguration;
@@ -47,7 +46,7 @@ public class RegistrationsTest extends PatchedActivityInstrumentationTestCase {
         PushConfiguration config = RegistrarManager
                 .config(PUSH, AeroGearGCMPushConfiguration.class)
                 .setPushServerURI(new URI("http://testreg.com"))
-                .setSenderIds("TestID")
+                .setSenderId("TestID")
                 .setVariantID("VariantID")
                 .setSecret("secret");
 

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushJsonConfigurationTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushJsonConfigurationTest.java
@@ -23,9 +23,6 @@ import org.jboss.aerogear.android.unifiedpush.test.MainActivity;
 import org.jboss.aerogear.android.unifiedpush.test.util.PatchedActivityInstrumentationTestCase;
 
 import java.net.URI;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,7 +31,7 @@ public class AeroGearGCMPushJsonConfigurationTest
         extends PatchedActivityInstrumentationTestCase {
 
     private static final URI pushServerURL = URI.create("https://localhost:8080/ag-push");
-    private static final Set<String> senderIds = new HashSet<String>(Arrays.asList("123456"));
+    private static final String senderId = "123456";
     private static final String variantID = "8abfae4eb02a6140c0a20798433180a063fd7006";
     private static final String secret = "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8";
 
@@ -48,7 +45,7 @@ public class AeroGearGCMPushJsonConfigurationTest
         config.loadConfigJson(getActivity());
 
         Assert.assertEquals(pushServerURL, config.getPushServerURI());
-        Assert.assertEquals(senderIds.iterator().next(), config.getSenderIds().iterator().next());
+        Assert.assertEquals(senderId, config.getSenderId());
         Assert.assertEquals(variantID, config.getVariantID());
         Assert.assertEquals(secret, config.getSecret());
     }
@@ -60,7 +57,7 @@ public class AeroGearGCMPushJsonConfigurationTest
         config.loadConfigJson(getActivity());
 
         Assert.assertEquals(pushServerURL, config.getPushServerURI());
-        Assert.assertEquals(senderIds.iterator().next(), config.getSenderIds().iterator().next());
+        Assert.assertEquals(senderId, config.getSenderId());
         Assert.assertEquals(variantID, config.getVariantID());
         Assert.assertEquals(secret, config.getSecret());
     }
@@ -79,7 +76,7 @@ public class AeroGearGCMPushJsonConfigurationTest
         }
 
         Assert.assertNull(config.getPushServerURI());
-        Assert.assertEquals(0, config.getSenderIds().size());
+        Assert.assertNull(config.getSenderId());
         Assert.assertNull(config.getVariantID());
         Assert.assertNull(config.getSecret());
     }

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -46,14 +46,7 @@
             <version>${aerogear.android.core.version}</version>
             <type>aar</type>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-android-core</artifactId>
-            <version>${aerogear.android.core.version}</version>
-            <type>jar</type>
-            <scope>provided</scope>
-        </dependency>        
+  
 
         <dependency>
             <groupId>org.jboss.aerogear</groupId>
@@ -61,14 +54,7 @@
             <version>${aerogear.android.pipe.version}</version>
             <type>aar</type>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-android-pipe</artifactId>
-            <version>${aerogear.android.pipe.version}</version>
-            <type>jar</type>
-            <scope>provided</scope>
-        </dependency>        
+      
 
         <!-- Seems like both projects need the APKLIB but don't if it is aar -->
         <dependency>
@@ -83,12 +69,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.google.android.gms</groupId>
-            <artifactId>play-services-gcm</artifactId>
-            <version>7.5.0</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -73,8 +73,8 @@
         <!-- Seems like both projects need the APKLIB but don't if it is aar -->
         <dependency>
             <groupId>com.google.android.gms</groupId>
-            <artifactId>play-services</artifactId>
-            <version>6.1.11</version>
+            <artifactId>play-services-gcm</artifactId>
+            <version>7.5.0</version>
             <type>aar</type>
             <exclusions>
                 <exclusion>
@@ -83,7 +83,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.android.gms</groupId>
+            <artifactId>play-services-gcm</artifactId>
+            <version>7.5.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushConfiguration.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushConfiguration.java
@@ -20,7 +20,6 @@ import org.jboss.aerogear.android.unifiedpush.PushConfiguration;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A Push Configuration which builds {@link AeroGearGCMPushRegistrar} instances.
@@ -51,39 +50,28 @@ public class AeroGearGCMPushConfiguration extends PushConfiguration<AeroGearGCMP
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
      * @return a copy of the current set of senderIds.
      * 
      */
-    public Set<String> getSenderIds() {
-        return pushConfig.getSenderIds();
+    public String getSenderId() {
+        return pushConfig.getSenderId();
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
-     * @param senderIds the new sender Ids to set.
+     * @param senderId the new senderId to set.
      * @return the current configuration.
      */
-    public AeroGearGCMPushConfiguration setSenderIds(String... senderIds) {
-        this.pushConfig.setSenderIds(senderIds);
+    public AeroGearGCMPushConfiguration setSenderId(String senderId) {
+        this.pushConfig.setSenderId(senderId);
         return this;
     }
 
-    /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
-     * this application.
-     * 
-     * @param senderId a new sender Id to add to the current set of senderIds.
-     * @return the current configuration.
-     */
-    public AeroGearGCMPushConfiguration addSenderId(String senderId) {
-        this.pushConfig.addSenderId(senderId);
-        return this;
-    }
 
     /**
      * ID of the Variant from the AeroGear UnifiedPush Server.

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushJsonConfiguration.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushJsonConfiguration.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A Push Configuration which builds {@link org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMPushRegistrar} instances.
@@ -63,25 +62,25 @@ public class AeroGearGCMPushJsonConfiguration
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
      * @return a copy of the current set of senderIds.
      * 
      */
-    public Set<String> getSenderIds() {
-        return pushConfig.getSenderIds();
+    public String getSenderId() {
+        return pushConfig.getSenderId();
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
      * @param senderId a new sender Id to add to the current set of senderIds.
      * @return the current configuration.
      */
-    public AeroGearGCMPushJsonConfiguration addSenderId(String senderId) {
-        this.pushConfig.addSenderId(senderId);
+    public AeroGearGCMPushJsonConfiguration setSenderId(String senderId) {
+        this.pushConfig.setSenderId(senderId);
         return this;
     }
 
@@ -291,7 +290,7 @@ public class AeroGearGCMPushJsonConfiguration
             JSONObject pushAndroidConfig = pushConfig.getJSONObject(JSON_OBJECT);
 
             this.pushConfig.setPushServerURI(new URI(pushConfig.getString(JSON_URL)));
-            this.pushConfig.addSenderId(pushAndroidConfig.getString(JSON_SENDER_ID));
+            this.pushConfig.setSenderId(pushAndroidConfig.getString(JSON_SENDER_ID));
             this.pushConfig.setVariantID(pushAndroidConfig.getString(JSON_VARIANT_ID));
             this.pushConfig.setSecret(pushAndroidConfig.getString(JSON_VARIANT_SECRET));
         } catch (URISyntaxException e) {

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
@@ -22,7 +22,7 @@ import java.util.*;
 public final class UnifiedPushConfig {
 
     private URI pushServerURI;
-    private Set<String> senderIds = new HashSet<String>();
+    private String senderId;
     private String variantID;
     private String secret;
     private String deviceToken = "";
@@ -54,41 +54,28 @@ public final class UnifiedPushConfig {
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
-     * @return a copy of the current set of senderIds.
+     * @return the current senderId.
      * 
      */
-    public Set<String> getSenderIds() {
-        return Collections.unmodifiableSet(senderIds);
+    public String getSenderId() {
+        return senderId;
     }
 
     /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
+     * SenderId is a  GCM sender Id (usually a project number) registered for 
      * this application.
      * 
-     * @param senderIds the new sender Ids to set.
+     * @param senderId the new senderId to set.
      * @return the current configuration.
      */
-    public UnifiedPushConfig setSenderIds(String... senderIds) {
-        Set<String> newSenderIds = new HashSet<String>(senderIds.length);
-        Collections.addAll(newSenderIds, senderIds);
-        this.senderIds = newSenderIds;
+    public UnifiedPushConfig setSenderId(String senderId) {
+        this.senderId = senderId;
         return this;
     }
 
-    /**
-     * SenderIds is a collection of all GCM sender Id elements registered for
-     * this application.
-     * 
-     * @param senderId a new sender Id to add to the current set of senderIds.
-     * @return the current configuration.
-     */
-    public UnifiedPushConfig addSenderId(String senderId) {
-        this.senderIds.add(senderId);
-        return this;
-    }
 
     /**
      * ID of the Variant from the AeroGear UnifiedPush Server.
@@ -299,8 +286,8 @@ public final class UnifiedPushConfig {
     }
 
     public void checkRequiredFields() {
-        if (senderIds == null || senderIds.isEmpty()) {
-            throw new IllegalStateException("SenderIds can't be null or empty");
+        if (senderId == null || senderId.isEmpty()) {
+            throw new IllegalStateException("SenderId can't be null or empty");
         }
 
         if (pushServerURI == null) {


### PR DESCRIPTION
@matzew @danielpassos :eyes: ?

# What has changed

* I've changed from using gcm.register to using InstanceId.  See: [AGDROID-469](https://issues.jboss.org/browse/AGDROID-469)
* I've made senderId a single value instead of a set.  See: [AG ML Thread](http://aerogear-dev.1069024.n5.nabble.com/aerogear-dev-Push-Registration-with-multiple-Senders-Android-td11895.html)
* As a "bonus" this PR also also handles [AGDROID-351](https://issues.jboss.org/browse/AGDROID-351).

# How to test
* Make sure you have the latest Android SDK installed and is fully up to date
* Make sure you have run the latest maven-android-sdk-deployer
* Make sure you have the latest aerogear-android-core, and -pipe
* Run the build while an android device or emulator running the Google Play APIs is connected
* You can also update the various helloworld/push quickstarts to use 3.0.0-SNAPSHOT and they should work as is.

# What to do if you have trouble
* Bother me on email 
* IRC
* This issue :)