### PR TITLE
Agdroid 486

### DIFF
--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-android-push-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-android-push</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <packaging>aar</packaging>
     <name>AeroGear Android Push Library</name>
     <url>http://aerogear.org</url>
@@ -28,14 +28,14 @@
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-android-push-parent</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
 
     <scm>
         <connection>scm:git:git@github.com:aerogear/aerogear-android-push.git</connection>
         <developerConnection>scm:git:git@github.com:aerogear/aerogear-android-push.git</developerConnection>
         <url>git@github.com:aerogear/aerogear-android-push.git</url>
-        <tag>2.2.0</tag>
+        <tag>2.2.1-SNAPSHOT</tag>
     </scm>
 
     <dependencies>

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
@@ -227,13 +227,15 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                     }
 
                     gcm.unregister();
-
+                    
                     HttpProvider provider = httpProviderProvider.get(deviceRegistryURL, TIMEOUT);
                     setPasswordAuthentication(variantId, secret, provider);
 
                     try {
                         provider.delete(deviceToken);
                         deviceToken = "";
+                        Log.i(TAG, "unsetting device token");
+                        setRegistrationId(context, deviceToken);
                         return null;
                     } catch (HttpException ex) {
                         return ex;
@@ -255,7 +257,7 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                 }
             }
 
-        }.execute((Void) null);
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, (Void) null);
     }
 
     /**
@@ -331,7 +333,7 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                 }
             }
 
-        }.execute((Void) null);
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, (Void) null);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-android-push-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>AeroGear Android Push Parent</name>
     <url>http://aerogear.org</url>
@@ -60,8 +60,8 @@
 
     <properties>
         <aerogear.bom.version>0.2.10</aerogear.bom.version>
-        <aerogear.android.core.version>2.2.0-SNAPSHOT</aerogear.android.core.version>
-        <aerogear.android.pipe.version>2.2.0-SNAPSHOT</aerogear.android.pipe.version>
+        <aerogear.android.core.version>2.1.0</aerogear.android.core.version>
+        <aerogear.android.pipe.version>2.1.0</aerogear.android.pipe.version>
 
         <!-- Plugins versions -->
         <maven.javadoc.plugin.version>2.9.1</maven.javadoc.plugin.version>


### PR DESCRIPTION
This fixes AGDROID-486.

How to Test:
Run mvn clean install while a device is attached or emulator is running.  You should see all tests pass.

Bonus Testing:
Register, unregister, and reregister a app to receive pushes.  The app should receive pushes.