### PR TITLE
Agdroid 470 topic messaging

### DIFF
--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -115,13 +115,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-<!--
-        <dependency>
-            <groupId>com.android.support.test</groupId>
-            <artifactId>runner</artifactId>
-            <version>${android.support.test.version}</version>
-            <scope>provided</scope>
-        </dependency>-->
 
         <dependency>
             <groupId>com.android.support.test</groupId>
@@ -146,19 +139,6 @@
             <version>${android.support.test.version}</version>
             <type>aar</type>
         </dependency>
-
-<!--        <dependency>
-            <groupId>com.android.support.test</groupId>
-            <artifactId>rules</artifactId>
-            <version>${android.support.test.version}</version>
-            <scope>provided</scope>
-        </dependency>-->
-<!--     <dependency>
-            <groupId>com.google.android.gms</groupId>
-            <artifactId>play-services-gcm</artifactId>
-            <version>${google.play.services.version}    </version>
-            <scope>provided</scope>
-        </dependency>-->
 
     </dependencies>
 

--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -32,11 +32,12 @@
     <properties>
 
         <!-- Dependencies versions -->
-        <android.support.v4.version>22.2.0</android.support.v4.version>
+        <android.support.v4.version>23.3.0</android.support.v4.version>
         <mockito.version>1.9.5</mockito.version>
         <dexmaker.version>1.0</dexmaker.version>
         <dexmaker.mockito.version>1.0</dexmaker.mockito.version>
         <android.support.test.version>0.5</android.support.test.version>
+        <google.play.services.version>8.4.0</google.play.services.version>
 
         <!-- Plugins parameters -->
         <android.maven.plugin.dex.xms>-Xms256m</android.maven.plugin.dex.xms>
@@ -72,13 +73,6 @@
             <groupId>org.jboss.aerogear</groupId>
             <artifactId>aerogear-android-core</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.android.support</groupId>
-            <artifactId>support-v4</artifactId>
-            <version>${android.support.v4.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -121,13 +115,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+<!--
         <dependency>
             <groupId>com.android.support.test</groupId>
             <artifactId>runner</artifactId>
             <version>${android.support.test.version}</version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
 
         <dependency>
             <groupId>com.android.support.test</groupId>
@@ -153,18 +147,18 @@
             <type>aar</type>
         </dependency>
 
-        <dependency>
+<!--        <dependency>
             <groupId>com.android.support.test</groupId>
             <artifactId>rules</artifactId>
             <version>${android.support.test.version}</version>
             <scope>provided</scope>
-        </dependency>
-     <dependency>
+        </dependency>-->
+<!--     <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-gcm</artifactId>
-            <version>7.5.0</version>
+            <version>${google.play.services.version}    </version>
             <scope>provided</scope>
-        </dependency>
+        </dependency>-->
 
     </dependencies>
 

--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -63,6 +63,26 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-push</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-android-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.android.support</groupId>
+            <artifactId>support-v4</artifactId>
+            <version>${android.support.v4.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
@@ -106,6 +126,13 @@
             <groupId>com.android.support.test</groupId>
             <artifactId>runner</artifactId>
             <version>${android.support.test.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>runner</artifactId>
+            <version>${android.support.test.version}</version>
             <type>aar</type>
             <exclusions>
                 <exclusion>
@@ -124,6 +151,19 @@
             <artifactId>rules</artifactId>
             <version>${android.support.test.version}</version>
             <type>aar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>rules</artifactId>
+            <version>${android.support.test.version}</version>
+            <scope>provided</scope>
+        </dependency>
+     <dependency>
+            <groupId>com.google.android.gms</groupId>
+            <artifactId>play-services-gcm</artifactId>
+            <version>7.5.0</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/aerogear-android-push-test/src/main/AndroidManifest.xml
+++ b/aerogear-android-push-test/src/main/AndroidManifest.xml
@@ -29,10 +29,10 @@
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <permission
-        android:name="org.jboss.aerogear.android.unifiedpush.permission.C2D_MESSAGE"
+        android:name="org.jboss.aerogear.android.unifiedpush.test.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
 
-    <uses-permission android:name="org.jboss.aerogear.android.unifiedpush.permission.C2D_MESSAGE" />
+    <uses-permission android:name="org.jboss.aerogear.android.unifiedpush.test.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     
@@ -58,6 +58,16 @@
                 <action android:name="com.google.android.gms.iid.InstanceID"/>
             </intent-filter>
         </service>
+        <receiver
+            android:name="org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMMessageReceiver"
+            android:permission="com.google.android.c2dm.permission.SEND">
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+                <action android:name="com.google.android.c2dm.intent.REGISTRATION"/>
+
+                <category android:name="org.jboss.aerogear.unifiedpush.helloworld.test"/>
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushJsonConfigurationTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushJsonConfigurationTest.java
@@ -23,6 +23,9 @@ import org.jboss.aerogear.android.unifiedpush.test.MainActivity;
 import org.jboss.aerogear.android.unifiedpush.test.util.PatchedActivityInstrumentationTestCase;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -106,6 +109,24 @@ public class AeroGearGCMPushJsonConfigurationTest
             String errorMessage = "An error occurred while parsing the blablabla.json. Please check if the file exists";
             Assert.assertEquals(errorMessage, e.getMessage());
         }
+    }
+
+    @Test
+    public void testSetCategoriesUsingStringArray() {
+        AeroGearGCMPushJsonConfiguration config = new AeroGearGCMPushJsonConfiguration();
+        config.setCategories("A", "B");
+        Assert.assertEquals(2, config.getCategories().size());
+    }
+
+    @Test
+    public void testSetCategoriesUsingList() {
+        List<String> myCategories = new ArrayList<String>();
+        myCategories.add("A");
+        myCategories.add("B");
+
+        AeroGearGCMPushJsonConfiguration config = new AeroGearGCMPushJsonConfiguration();
+        config.setCategories(myCategories);
+        Assert.assertEquals(2, config.getCategories().size());
     }
 
 }

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushRegistrarTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/AeroGearGCMPushRegistrarTest.java
@@ -17,6 +17,7 @@
 package org.jboss.aerogear.android.unifiedpush.test.gcm;
 
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
@@ -50,6 +51,7 @@ import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -115,21 +117,32 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         CountDownLatch latch = new CountDownLatch(1);
         StubHttpProvider provider = new StubHttpProvider();
         UnitTestUtils.setPrivateField(registrar, "httpProviderProvider", provider);
+                
+        StubInstanceIDProvider instanceIdProvider = new StubInstanceIDProvider();
+        UnitTestUtils.setPrivateField(registrar, "instanceIdProvider", instanceIdProvider);
+
         VoidCallback callback = new VoidCallback(latch);
 
+        final GcmPubSub mockPubSub = Mockito.mock(GcmPubSub.class);
+        Mockito.doNothing().when(mockPubSub).unsubscribe(anyString(), anyString());
+        Mockito.doNothing().when(mockPubSub).subscribe(anyString(), anyString(), any(Bundle.class));
+        
+        Provider gcmPubSubProvider = new Provider<GcmPubSub>() {
+
+            @Override
+            public GcmPubSub get(Object... in) {
+                return mockPubSub;
+            }
+
+                
+        };;
+        UnitTestUtils.setPrivateField(registrar, "gcmPubProvider", gcmPubSubProvider);
+
+        
         registrar.register(super.getActivity(), callback);
         if (!latch.await(60, TimeUnit.SECONDS)) {
             try {
-                Process process = Runtime.getRuntime().exec("logcat -d");
-                BufferedReader bufferedReader = new BufferedReader(
-                        new InputStreamReader(process.getInputStream()));
-
-                StringBuilder log = new StringBuilder();
-                String line = "";
-                while ((line = bufferedReader.readLine()) != null) {
-                    log.append(line);
-                }
-                Log.e(TAG, log.toString());    
+                writeLogcatLogs();
             } catch (IOException e) {
                 Log.e(TAG, e.getMessage(), e);    
             }
@@ -149,6 +162,9 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         Assert.assertNotNull(jsonData);
         Assert.assertEquals(UnitTestUtils.getPrivateField(registrar, "deviceToken"), new JSONObject(jsonData).getString("deviceToken"));
         Assert.assertEquals(new JSONArray(CATEGORIES).length(), new JSONObject(jsonData).getJSONArray("categories").length());
+        Mockito.verify(mockPubSub, Mockito.times(1)).subscribe(StubInstanceIDProvider.TEMP_ID, "/topics/test", null);
+        Mockito.verify(mockPubSub, Mockito.times(1)).subscribe(StubInstanceIDProvider.TEMP_ID, "/topics/anotherTest", null);
+        Mockito.verify(mockPubSub, Mockito.times(1)).subscribe(StubInstanceIDProvider.TEMP_ID, "/topics/" + TEST_SENDER_VARIANT, null);
     }
 
     @Test
@@ -170,6 +186,7 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
 
         final GcmPubSub mockPubSub = Mockito.mock(GcmPubSub.class);
         Mockito.doNothing().when(mockPubSub).unsubscribe(anyString(), anyString());
+        Mockito.doNothing().when(mockPubSub).subscribe(anyString(), anyString(), any(Bundle.class));
         
         Provider gcmPubSubProvider = new Provider<GcmPubSub>() {
 
@@ -204,6 +221,7 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         Mockito.verify(provider.mock).delete(Mockito.matches("tempId"));
         Mockito.verify(mockPubSub, Mockito.times(1)).unsubscribe(StubInstanceIDProvider.TEMP_ID, "/topics/test");
         Mockito.verify(mockPubSub, Mockito.times(1)).unsubscribe(StubInstanceIDProvider.TEMP_ID, "/topics/anotherTest");
+        Mockito.verify(mockPubSub, Mockito.times(1)).unsubscribe(StubInstanceIDProvider.TEMP_ID, "/topics/" + TEST_SENDER_VARIANT);
         Assert.assertNull(callback.exception);
         Assert.assertEquals("", UnitTestUtils.getPrivateField(registrar, "deviceToken"));
     }
@@ -262,6 +280,23 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         AeroGearGCMPushRegistrar registrar = (AeroGearGCMPushRegistrar) config.asRegistrar();
         CountDownLatch latch = new CountDownLatch(1);
         StubHttpProvider provider = new StubHttpProvider();
+        
+        final GcmPubSub mockPubSub = Mockito.mock(GcmPubSub.class);
+        Mockito.doNothing().when(mockPubSub).unsubscribe(anyString(), anyString());
+        Mockito.doNothing().when(mockPubSub).subscribe(anyString(), anyString(), any(Bundle.class));
+        
+        Provider gcmPubSubProvider = new Provider<GcmPubSub>() {
+
+            @Override
+            public GcmPubSub get(Object... in) {
+                return mockPubSub;
+            }
+
+                
+        };;
+        UnitTestUtils.setPrivateField(registrar, "gcmPubProvider", gcmPubSubProvider);
+
+        
         UnitTestUtils.setPrivateField(registrar, "httpProviderProvider", provider);
 
         StubInstanceIDProvider instanceIdProvider = new StubInstanceIDProvider();
@@ -274,9 +309,15 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         spy.register(super.getActivity(), callback);
         latch.await(1, TimeUnit.SECONDS);
 
-        latch = new CountDownLatch(2);
+        latch = new CountDownLatch(1);
         callback = new VoidCallback(latch);
         spy.unregister(super.getActivity(), callback);
+        latch.await(4, TimeUnit.SECONDS);
+        
+        Assert.assertNull(callback.exception);
+        
+        latch = new CountDownLatch(1);
+        callback = new VoidCallback(latch);
         spy.unregister(super.getActivity(), callback);
         latch.await(4, TimeUnit.SECONDS);
 
@@ -296,6 +337,23 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
 
         AeroGearGCMPushRegistrar registrar = (AeroGearGCMPushRegistrar) config.asRegistrar();
         CountDownLatch latch = new CountDownLatch(1);
+        
+                final GcmPubSub mockPubSub = Mockito.mock(GcmPubSub.class);
+        Mockito.doNothing().when(mockPubSub).unsubscribe(anyString(), anyString());
+        Mockito.doNothing().when(mockPubSub).subscribe(anyString(), anyString(), any(Bundle.class));
+        
+        Provider gcmPubSubProvider = new Provider<GcmPubSub>() {
+
+            @Override
+            public GcmPubSub get(Object... in) {
+                return mockPubSub;
+            }
+
+                
+        };;
+        UnitTestUtils.setPrivateField(registrar, "gcmPubProvider", gcmPubSubProvider);
+
+        
         StubHttpProvider provider = new StubHttpProvider();
         UnitTestUtils.setPrivateField(registrar, "httpProviderProvider", provider);
 
@@ -320,6 +378,7 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
         callback = new VoidCallback(latch);
         registrar.unregister(super.getActivity(), callback);
         latch.await(5, TimeUnit.SECONDS);
+        Assert.assertNull(callback.exception);
         Assert.assertNull(new GCMSharedPreferenceProvider().get(getActivity()).getString("org.jboss.aerogear.android.unifiedpush.gcm.AeroGearGCMPushRegistrar:" + TEST_SENDER_ID, null));
         Mockito.verify(instanceIdProvider.mock, Mockito.times(1)).deleteToken(Mockito.eq(TEST_SENDER_ID), Mockito.eq(GoogleCloudMessaging.INSTANCE_ID_SCOPE));
     }
@@ -363,6 +422,19 @@ public class AeroGearGCMPushRegistrarTest extends PatchedActivityInstrumentation
 
         Assert.fail();
 
+    }
+
+    private void writeLogcatLogs() throws IOException {
+        Process process = Runtime.getRuntime().exec("logcat -d");
+        BufferedReader bufferedReader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()));
+
+        StringBuilder log = new StringBuilder();
+        String line = "";
+        while ((line = bufferedReader.readLine()) != null) {
+            log.append(line);
+        }
+        Log.e(TAG, log.toString());    
     }
 
     static class StubHttpProvider implements Provider<HttpProvider> {

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/InstanceIdListenerTests.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/gcm/InstanceIdListenerTests.java
@@ -65,9 +65,11 @@ public class InstanceIdListenerTests extends PatchedActivityInstrumentationTestC
         VoidCallback callback = new VoidCallback(latch);
 
         registrar.register(super.getActivity(), callback);
+        
         if (!latch.await(30, TimeUnit.SECONDS)) {
             Assert.fail("Latch wasn't called");
         }
+        Assert.assertNotNull(new GCMSharedPreferenceProvider().get(getActivity()).getString(TEST_REGISTRAR_PREFERENCES_KEY, null));
     }
     
     @Test

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -83,6 +83,14 @@
             <scope>provided</scope>
         </dependency>        
 
+
+        <dependency>
+            <groupId>com.google.android.gms</groupId>
+            <artifactId>play-services-gcm</artifactId>
+            <version>${google.play.services.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-gcm</artifactId>

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -83,14 +83,6 @@
             <scope>provided</scope>
         </dependency>        
 
-
-        <dependency>
-            <groupId>com.google.android.gms</groupId>
-            <artifactId>play-services-gcm</artifactId>
-            <version>${google.play.services.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-gcm</artifactId>

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushConfiguration.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushConfiguration.java
@@ -294,5 +294,5 @@ public class AeroGearGCMPushConfiguration extends PushConfiguration<AeroGearGCMP
         pushConfig.checkRequiredFields();
         return new AeroGearGCMPushRegistrar(pushConfig);
     }
-
+    
 }

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
@@ -22,6 +22,7 @@ import android.os.AsyncTask;
 import android.util.Base64;
 import android.util.Log;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
+import com.google.android.gms.gcm.GcmPubSub;
 import com.google.android.gms.iid.InstanceID;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -39,6 +40,7 @@ import org.jboss.aerogear.android.unifiedpush.metrics.UnifiedPushMetricsMessage;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 
 public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<UnifiedPushMetricsMessage> {
@@ -159,6 +161,9 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                         postData.addProperty("variantId", variantId);
                         postData.addProperty("secret", secret);
                         presistPostInformation(context.getApplicationContext(), postData);
+                        for (String catgory : categories) {
+                            GcmPubSub.getInstance(context).subscribe(deviceToken, "/topics/" + URLEncoder.encode(catgory), null);
+                        }
                         return null;
                     } catch (HttpException ex) {
                         return ex;
@@ -230,6 +235,10 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                         instanceId = instanceIdProvider.get(context);
                     }
 
+                    for (String catgory : categories) {
+                            GcmPubSub.getInstance(context).unsubscribe(deviceToken, "/topics/" + URLEncoder.encode(catgory));
+                    }
+                    
                     instanceId.deleteToken(senderId, GoogleCloudMessaging.INSTANCE_ID_SCOPE);
 
                     HttpProvider provider = httpProviderProvider.get(deviceRegistryURL, TIMEOUT);

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
@@ -171,8 +171,11 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                         GcmPubSub gcmPubSub = gcmPubProvider.get(context);
                     
                         for (String catgory : categories) {
-                            gcmPubSub.getInstance(context).subscribe(deviceToken, "/topics/" + catgory, null);
+                            gcmPubSub.subscribe(deviceToken, "/topics/" + catgory, null);
                         }
+                        
+                        //Subscribe to global topic
+                        gcmPubSub.subscribe(deviceToken, "/topics/" + variantId, null);
                         return null;
                     } catch (HttpException ex) {
                         return ex;
@@ -249,6 +252,9 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                     for (String catgory : categories) {
                             gcmPubSub.unsubscribe(deviceToken, "/topics/" + catgory);
                     }
+                    
+                    //Unsubscribe to generic topic
+                    gcmPubSub.unsubscribe(deviceToken, "/topics/" + variantId);
                     
                     instanceId.deleteToken(senderId, GoogleCloudMessaging.INSTANCE_ID_SCOPE);
 

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/AeroGearGCMPushRegistrar.java
@@ -40,7 +40,6 @@ import org.jboss.aerogear.android.unifiedpush.metrics.UnifiedPushMetricsMessage;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 
 public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<UnifiedPushMetricsMessage> {
@@ -96,6 +95,14 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
         @Override
         public InstanceID get(Object... context) {
             return InstanceID.getInstance((Context) context[0]);
+        }
+    };
+    
+    private Provider<GcmPubSub> gcmPubProvider = new Provider<GcmPubSub>() {
+
+        @Override
+        public GcmPubSub get(Object... context) {
+            return GcmPubSub.getInstance((Context) context[0]);
         }
     };
     
@@ -161,8 +168,10 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                         postData.addProperty("variantId", variantId);
                         postData.addProperty("secret", secret);
                         presistPostInformation(context.getApplicationContext(), postData);
+                        GcmPubSub gcmPubSub = gcmPubProvider.get(context);
+                    
                         for (String catgory : categories) {
-                            GcmPubSub.getInstance(context).subscribe(deviceToken, "/topics/" + URLEncoder.encode(catgory), null);
+                            gcmPubSub.getInstance(context).subscribe(deviceToken, "/topics/" + catgory, null);
                         }
                         return null;
                     } catch (HttpException ex) {
@@ -234,9 +243,11 @@ public class AeroGearGCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                     if (instanceId == null) {
                         instanceId = instanceIdProvider.get(context);
                     }
-
+                    
+                    GcmPubSub gcmPubSub = gcmPubProvider.get(context);
+                    
                     for (String catgory : categories) {
-                            GcmPubSub.getInstance(context).unsubscribe(deviceToken, "/topics/" + URLEncoder.encode(catgory));
+                            gcmPubSub.unsubscribe(deviceToken, "/topics/" + catgory);
                     }
                     
                     instanceId.deleteToken(senderId, GoogleCloudMessaging.INSTANCE_ID_SCOPE);

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
@@ -1,18 +1,18 @@
 /**
- * JBoss, Home of Professional Open Source
- * Copyright Red Hat, Inc., and individual contributors.
+ * JBoss, Home of Professional Open Source Copyright Red Hat, Inc., and
+ * individual contributors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.jboss.aerogear.android.unifiedpush.gcm;
 
@@ -32,9 +32,16 @@ public final class UnifiedPushConfig {
     private String alias;
     private List<String> categories = new ArrayList<String>();
 
+    
+    /**
+     * Topics in GCM must conform to this pattern.
+     * See : https://developers.google.com/android/reference/com/google/android/gms/gcm/GcmPubSub#unsubscribe(java.lang.String, java.lang.String)
+     */
+    private static final String GCM_TOPIC_PATTERN = "[a-zA-Z0-9-_.~%]{1,900}";
+    
     /**
      * RegistryURL is the URL of the 3rd party application server
-     * 
+     *
      * @return the current pushServerURI
      */
     public URI getPushServerURI() {
@@ -43,10 +50,10 @@ public final class UnifiedPushConfig {
 
     /**
      * RegistryURL is the URL of the 3rd party application server
-     * 
+     *
      * @param pushServerURI a new URI
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setPushServerURI(URI pushServerURI) {
         this.pushServerURI = pushServerURI;
@@ -54,20 +61,20 @@ public final class UnifiedPushConfig {
     }
 
     /**
-     * SenderId is a  GCM sender Id (usually a project number) registered for 
+     * SenderId is a GCM sender Id (usually a project number) registered for
      * this application.
-     * 
+     *
      * @return the current senderId.
-     * 
+     *
      */
     public String getSenderId() {
         return senderId;
     }
 
     /**
-     * SenderId is a  GCM sender Id (usually a project number) registered for 
+     * SenderId is a GCM sender Id (usually a project number) registered for
      * this application.
-     * 
+     *
      * @param senderId the new senderId to set.
      * @return the current configuration.
      */
@@ -76,10 +83,9 @@ public final class UnifiedPushConfig {
         return this;
     }
 
-
     /**
      * ID of the Variant from the AeroGear UnifiedPush Server.
-     * 
+     *
      * @return the current variant id
      */
     public String getVariantID() {
@@ -88,7 +94,7 @@ public final class UnifiedPushConfig {
 
     /**
      * ID of the Variant from the AeroGear UnifiedPush Server.
-     * 
+     *
      * @param variantID the new variantID
      * @return the current configuration
      */
@@ -99,9 +105,9 @@ public final class UnifiedPushConfig {
 
     /**
      * Secret of the Variant from the AeroGear UnifiedPush Server.
-     * 
+     *
      * @return the current Secret
-     * 
+     *
      */
     public String getSecret() {
         return secret;
@@ -109,7 +115,7 @@ public final class UnifiedPushConfig {
 
     /**
      * Secret of the Variant from the AeroGear UnifiedPush Server.
-     * 
+     *
      * @param secret the new secret
      * @return the current configuration
      */
@@ -121,9 +127,9 @@ public final class UnifiedPushConfig {
     /**
      * The device token Identifies the device within its Push Network. It is the
      * value = GoogleCloudMessaging.getInstance(context).register(SENDER_ID);
-     * 
+     *
      * @return the current device token
-     * 
+     *
      */
     public String getDeviceToken() {
         return deviceToken;
@@ -132,10 +138,10 @@ public final class UnifiedPushConfig {
     /**
      * The device token Identifies the device within its Push Network. It is the
      * value = GoogleCloudMessaging.getInstance(context).register(SENDER_ID);
-     * 
+     *
      * @param deviceToken the new device token
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setDeviceToken(String deviceToken) {
         this.deviceToken = deviceToken;
@@ -145,9 +151,9 @@ public final class UnifiedPushConfig {
     /**
      * Device type determines which cloud messaging system will be used by the
      * AeroGear Unified Push Server
-     * 
+     *
      * Defaults to ANDROID
-     * 
+     *
      * @return the device type
      */
     public String getDeviceType() {
@@ -157,12 +163,12 @@ public final class UnifiedPushConfig {
     /**
      * Device type determines which cloud messaging system will be used by the
      * AeroGear Unified Push Server.
-     * 
+     *
      * Defaults to ANDROID
-     * 
+     *
      * @param deviceType a new device type
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setDeviceType(String deviceType) {
         this.deviceType = deviceType;
@@ -171,7 +177,7 @@ public final class UnifiedPushConfig {
 
     /**
      * The name of the operating system. Defaults to Android
-     * 
+     *
      * @return the operating system
      */
     public String getOperatingSystem() {
@@ -180,7 +186,7 @@ public final class UnifiedPushConfig {
 
     /**
      * The name of the operating system. Defaults to Android
-     * 
+     *
      * @param operatingSystem the new operating system
      * @return the current configuration
      */
@@ -191,11 +197,11 @@ public final class UnifiedPushConfig {
 
     /**
      * The version of the operating system running.
-     * 
+     *
      * Defaults to the value provided by android.os.Build.VERSION.RELEASE
-     * 
+     *
      * @return the current OSversion
-     * 
+     *
      */
     public String getOsVersion() {
         return osVersion;
@@ -203,11 +209,11 @@ public final class UnifiedPushConfig {
 
     /**
      * The Alias is an identifier of the user of the system.
-     * 
+     *
      * Examples are an email address or a username
-     * 
+     *
      * @return alias
-     * 
+     *
      */
     public String getAlias() {
         return alias;
@@ -215,12 +221,12 @@ public final class UnifiedPushConfig {
 
     /**
      * The Alias is an identifier of the user of the system.
-     * 
+     *
      * Examples are an email address or a username
-     * 
+     *
      * @param alias the new alias
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setAlias(String alias) {
         this.alias = alias;
@@ -229,9 +235,9 @@ public final class UnifiedPushConfig {
 
     /**
      * The categories specifies a channel which may be used to send messages
-     * 
+     *
      * @return the current categories
-     * 
+     *
      */
     public List<String> getCategories() {
         return Collections.unmodifiableList(categories);
@@ -239,48 +245,52 @@ public final class UnifiedPushConfig {
 
     /**
      * The categories specifies a channel which may be used to send messages
-     * 
+     *
      * @param categories the new categories
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setCategories(List<String> categories) {
-        this.categories = categories;
+        validateCategories(categories.toArray(new String[categories.size()]));        
+        this.categories = new ArrayList<String>(categories);
         return this;
     }
 
     /**
      * The categories specifies a channel which may be used to send messages
-     * 
+     *
      * @param categories the new categories
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig setCategories(String... categories) {
+        validateCategories(categories);        
         this.categories = Arrays.asList(categories);
         return this;
     }
 
     /**
      * The categories specifies a channel which may be used to send messages
-     * 
+     *
      * @param category a new category to be added to the current list.
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig addCategory(String category) {
+        validateCategories(category);        
         categories.add(category);
         return this;
     }
 
     /**
      * The categories specifies a channel which may be used to send messages
-     * 
+     *
      * @param categories a category collection to be added to the current list.
      * @return the current configuration
-     * 
+     *
      */
     public UnifiedPushConfig addCategories(List<String> categories) {
+        validateCategories(categories.toArray(new String[categories.size()]));
         this.categories.addAll(categories);
         return this;
     }
@@ -300,6 +310,23 @@ public final class UnifiedPushConfig {
 
         if (secret == null) {
             throw new IllegalStateException("Secret can't be null");
+        }
+    }
+
+    /**
+     * Validates categories against Google's pattern.
+     *
+     * @param categories a group of Strings each will be validated.
+     *
+     * @throws IllegalArgumentException if a category fails to match
+     * [a-zA-Z0-9-_.~%]{1,900}
+     */
+    private static void validateCategories(String... categories) {
+
+        for (String category : categories) {
+            if (!category.matches(GCM_TOPIC_PATTERN)) {
+                throw new IllegalArgumentException(String.format("%s does not match %s", category, GCM_TOPIC_PATTERN));
+            }
         }
     }
 

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/gcm/UnifiedPushConfig.java
@@ -245,7 +245,7 @@ public final class UnifiedPushConfig {
      * 
      */
     public UnifiedPushConfig setCategories(List<String> categories) {
-        this.categories = new ArrayList<String>(categories);
+        this.categories = categories;
         return this;
     }
 


### PR DESCRIPTION
# How to test (requires a UPS feature branch)
 * Build the project.  Ask in #aerogear or on aerogear-dev if you need help
 * Build the gcm-topics PR for UPS
 * Configure a push variant etc etc in UPS
 * Configure a sample application (I used the hello world)
 * In the sample application add a category "topic" (or anything you want) to the Push Registrar config
 * In UPS sent a message to the device.  In the UPS log you will see Sending payload for [1] devices to GCM
 * Now send a message but set the category to "topic" (or whatever you set in step *)
 * In UPS you should see  Sending payload for [1] topics to GCM
 *  You should also see both messages in the app.