### PR TITLE
Token fix

### DIFF
--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/fcm/AeroGearFCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/fcm/AeroGearFCMPushRegistrar.java
@@ -144,7 +144,7 @@ public class AeroGearFCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                     if (instanceId == null) {
                         instanceId = firebaseInstanceIdProvider.get(context);
                     }
-                    String token = instanceId.getToken();
+                    String token = instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
 
                     deviceToken = token;
 

--- a/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/fcm/AeroGearFCMPushRegistrar.java
+++ b/aerogear-android-push/src/main/java/org/jboss/aerogear/android/unifiedpush/fcm/AeroGearFCMPushRegistrar.java
@@ -144,7 +144,16 @@ public class AeroGearFCMPushRegistrar implements PushRegistrar, MetricsSender<Un
                     if (instanceId == null) {
                         instanceId = firebaseInstanceIdProvider.get(context);
                     }
-                    String token = instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
+                    
+                    /*
+                    The getToken method will return a cached token.  If the 
+                    token is null then we need to force a token to be loaded.
+                    */
+                    String token = instanceId.getToken();
+                    
+                    if (token == null) {
+                        token = instanceId.getToken(senderId, FirebaseMessaging.INSTANCE_ID_SCOPE);
+                    }
 
                     deviceToken = token;
 


### PR DESCRIPTION
This code will now force a instanceID token to load.  In the future we should explore signalling if the other "getToken" method is safe to call.