### PR TITLE
Updating Android and dependant libraries

### DIFF
--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -32,12 +32,11 @@
     <properties>
 
         <!-- Dependencies versions -->
-        <android.support.v4.version>23.3.0</android.support.v4.version>
+        <android.support.v4.version>24.2.1</android.support.v4.version>
         <mockito.version>1.9.5</mockito.version>
         <dexmaker.version>1.0</dexmaker.version>
         <dexmaker.mockito.version>1.0</dexmaker.mockito.version>
         <android.support.test.version>0.5</android.support.test.version>
-        <google.play.services.version>8.4.0</google.play.services.version>
 
         <!-- Plugins parameters -->
         <android.maven.plugin.dex.xms>-Xms256m</android.maven.plugin.dex.xms>

--- a/aerogear-android-push/pom.xml
+++ b/aerogear-android-push/pom.xml
@@ -43,7 +43,7 @@
         <!-- Dependencies versions -->
         <aerogear.android.core.version>3.0.0</aerogear.android.core.version>
         <aerogear.android.pipe.version>3.0.0</aerogear.android.pipe.version>
-        <firebase.version>9.0.0</firebase.version>
+        <firebase.version>9.4.0</firebase.version>
 
         <!-- Plugins versions -->
         <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <maven.android.plugin.version>4.4.1</maven.android.plugin.version>
 
         <!-- Android configs -->
-        <android.platform>23</android.platform>
+        <android.platform>24</android.platform>
         <android.debug>false</android.debug>
         <proguard.skip>true</proguard.skip>
     </properties>


### PR DESCRIPTION
@matzew This should fix the library version issues I saw.  You will probably need to rerun the sdk deployer if you haven't in a while.

# Steps to test
 Clone and configure the HelloPush cookbook app
 Update the build.gradle in the cookbook app to use this version of the library (4.0.2-SNAPSHOT) (You may have to add mavenLocal() to you global repositories in the root project's build.gradle file)
 You should be able to build and run the project without errors in the console/app.