### PR TITLE
Rolling back to Android 23 and build tools 23

### DIFF
--- a/aerogear-android-push-test/pom.xml
+++ b/aerogear-android-push-test/pom.xml
@@ -32,7 +32,7 @@
     <properties>
 
         <!-- Dependencies versions -->
-        <android.support.v4.version>24.2.1</android.support.v4.version>
+        <android.support.v4.version>23.2.1</android.support.v4.version>
         <mockito.version>1.9.5</mockito.version>
         <dexmaker.version>1.0</dexmaker.version>
         <dexmaker.mockito.version>1.0</dexmaker.mockito.version>
@@ -138,7 +138,13 @@
             <version>${android.support.test.version}</version>
             <type>aar</type>
         </dependency>
-
+        <dependency>
+            <groupId>android</groupId>
+            <artifactId>android</artifactId>
+            <version>4.1.2_r5</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -153,6 +159,7 @@
                     </test>
                     <sdk>
                         <platform>${android.platform}</platform>
+                        <buildTools>${android.buildTools}</buildTools>
                     </sdk>
                     <proguard>
                         <skip>${proguard.skip}</skip>

--- a/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/fcm/AeroGearFCMPushRegistrarTest.java
+++ b/aerogear-android-push-test/src/main/java/org/jboss/aerogear/android/unifiedpush/test/fcm/AeroGearFCMPushRegistrarTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -158,7 +159,7 @@ public class AeroGearFCMPushRegistrarTest extends PatchedActivityInstrumentation
         String jsonData = new FCMSharedPreferenceProvider().get(getActivity()).getString(TEST_REGISTRAR_PREFERENCES_KEY, TAG);
         Assert.assertNotNull(jsonData);
         Assert.assertEquals(UnitTestUtils.getPrivateField(registrar, "deviceToken"), new JSONObject(jsonData).getString("deviceToken"));
-        Assert.assertEquals(new JSONArray(CATEGORIES).length(), new JSONObject(jsonData).getJSONArray("categories").length());
+        Assert.assertEquals(new JSONArray(Arrays.asList(CATEGORIES)).length(), new JSONObject(jsonData).getJSONArray("categories").length());
         Mockito.verify(mockPubSub, Mockito.times(1)).subscribeToTopic("test");
         Mockito.verify(mockPubSub, Mockito.times(1)).subscribeToTopic("anotherTest");
         Mockito.verify(mockPubSub, Mockito.times(1)).subscribeToTopic(TEST_SENDER_VARIANT);

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@
         <maven.android.plugin.version>4.4.1</maven.android.plugin.version>
 
         <!-- Android configs -->
-        <android.platform>24</android.platform>
+        <android.platform>23</android.platform>
+        <android.buildTools>23.0.2</android.buildTools>
         <android.debug>false</android.debug>
         <proguard.skip>true</proguard.skip>
     </properties>


### PR DESCRIPTION
# Motivation

When we target Android N and the latest build tools we are also bringing in a compile dependency on Java 8.  We would prefer this to be a major version change and have rolled back that change.  Additionally org.json classes stopped compiling so I added a compile time dependency on the Android 4.1 runtime (our minimum)

# How to test
Ensure you are running the latest Android versions by updating your Android SDK and running the maven android sdk deployer.  Start an Android emulator and then run with Java 7 mvn clean install from the project root.